### PR TITLE
Feat/merchant bulk discount delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,12 @@ In this example, Item A1 should discounted at 20% off, and Item A2 should discou
   - And I see my new bulk discount listed
 
 ##### 3. Merchant Bulk Discount Delete
-  As a merchant
-  When I visit my bulk discounts index
-  Then next to each bulk discount I see a link to delete it
-  When I click this link
-  Then I am redirected back to the bulk discounts index page
-  And I no longer see the discount listed
+  - As a merchant
+  - When I visit my bulk discounts index
+  - Then next to each bulk discount I see a link to delete it
+  - When I click this link
+  - Then I am redirected back to the bulk discounts index page
+  - And I no longer see the discount listed
 
 ##### 4. Merchant Bulk Discount Show
   As a merchant

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -20,6 +20,13 @@ class BulkDiscountsController < ApplicationController
     redirect_to merchant_bulk_discounts_path(params[:merchant_id])
   end
 
+  def destroy
+    merchant = Merchant.find(params[:merchant_id])
+    @discount = merchant.bulk_discounts.find(params[:id]).destroy
+
+    redirect_to merchant_bulk_discounts_path(params[:merchant_id])
+  end
+
   private
   def bulk_discount_params
     params.permit(:percentage_discount,

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -6,5 +6,6 @@
     Percentage of Discount: <%= "#{discount.percentage_discount.to_i}%" %>
     Threshold: <%= discount.quantity_threshold %> items
     <%= link_to "View More", merchant_bulk_discount_path(discount.merchant, discount) , method: :get%>
+    <%= link_to "Delete Discount", merchant_bulk_discount_path(discount.merchant, discount) , method: :delete%>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :show, :new, :create]
+    resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy]
   end
 
   namespace :admin do

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -45,8 +45,6 @@ RSpec.describe BulkDiscount do
 
       visit merchant_bulk_discounts_path(@merchant1)
   
-
-
       expect(page).to have_link("Create New Discount")
 
       click_link "Create New Discount"
@@ -61,6 +59,60 @@ RSpec.describe BulkDiscount do
       expect(current_path).to eq(merchant_bulk_discounts_path(@merchant1))
       expect(page).to have_content("Percentage of Discount: 20%")
       expect(page).to have_content("Percentage of Discount: 50%")
+    end
+  end
+
+  describe 'Merchant Bulk Discount Delete' do
+    it 'can delete discounts' do
+      @merchant1 = Merchant.create!(name: 'Hair Care')
+
+      @customer_1 = Customer.create!(first_name: 'Joey', last_name: 'Smith')
+      @customer_2 = Customer.create!(first_name: 'Cecilia', last_name: 'Jones')
+      @customer_3 = Customer.create!(first_name: 'Mariah', last_name: 'Carrey')
+      @customer_4 = Customer.create!(first_name: 'Leigh Ann', last_name: 'Bron')
+      @customer_5 = Customer.create!(first_name: 'Sylvester', last_name: 'Nader')
+      @customer_6 = Customer.create!(first_name: 'Herber', last_name: 'Kuhn')
+
+      @invoice_1 = Invoice.create!(customer_id: @customer_1.id, status: 2)
+      @invoice_2 = Invoice.create!(customer_id: @customer_1.id, status: 2)
+      @invoice_3 = Invoice.create!(customer_id: @customer_2.id, status: 2)
+      @invoice_4 = Invoice.create!(customer_id: @customer_3.id, status: 2)
+      @invoice_5 = Invoice.create!(customer_id: @customer_4.id, status: 2)
+      @invoice_6 = Invoice.create!(customer_id: @customer_5.id, status: 2)
+      @invoice_7 = Invoice.create!(customer_id: @customer_6.id, status: 1)
+
+      @item_1 = Item.create!(name: "Shampoo", description: "This washes your hair", unit_price: 10, merchant_id: @merchant1.id)
+      @item_2 = Item.create!(name: "Conditioner", description: "This makes your hair shiny", unit_price: 8, merchant_id: @merchant1.id)
+      @item_3 = Item.create!(name: "Brush", description: "This takes out tangles", unit_price: 5, merchant_id: @merchant1.id)
+      @item_4 = Item.create!(name: "Hair tie", description: "This holds up your hair", unit_price: 1, merchant_id: @merchant1.id)
+
+      @ii_1 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_1.id, quantity: 1, unit_price: 10, status: 0)
+      @ii_2 = InvoiceItem.create!(invoice_id: @invoice_1.id, item_id: @item_2.id, quantity: 1, unit_price: 8, status: 0)
+      @ii_3 = InvoiceItem.create!(invoice_id: @invoice_2.id, item_id: @item_3.id, quantity: 1, unit_price: 5, status: 2)
+      @ii_4 = InvoiceItem.create!(invoice_id: @invoice_3.id, item_id: @item_4.id, quantity: 1, unit_price: 5, status: 1)
+      @ii_5 = InvoiceItem.create!(invoice_id: @invoice_4.id, item_id: @item_4.id, quantity: 1, unit_price: 5, status: 1)
+      @ii_6 = InvoiceItem.create!(invoice_id: @invoice_5.id, item_id: @item_4.id, quantity: 1, unit_price: 5, status: 1)
+      @ii_7 = InvoiceItem.create!(invoice_id: @invoice_6.id, item_id: @item_4.id, quantity: 1, unit_price: 5, status: 1)
+
+      @transaction1 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_1.id)
+      @transaction2 = Transaction.create!(credit_card_number: 230948, result: 1, invoice_id: @invoice_3.id)
+      @transaction3 = Transaction.create!(credit_card_number: 234092, result: 1, invoice_id: @invoice_4.id)
+      @transaction4 = Transaction.create!(credit_card_number: 230429, result: 1, invoice_id: @invoice_5.id)
+      @transaction5 = Transaction.create!(credit_card_number: 102938, result: 1, invoice_id: @invoice_6.id)
+      @transaction6 = Transaction.create!(credit_card_number: 879799, result: 1, invoice_id: @invoice_7.id)
+      @transaction7 = Transaction.create!(credit_card_number: 203942, result: 1, invoice_id: @invoice_2.id)
+
+      bd1 = BulkDiscount.create!(percentage_discount: 20.0, quantity_threshold: 10, merchant_id: @merchant1.id)
+
+      visit merchant_bulk_discounts_path(@merchant1)
+
+      within(".discount-#{bd1.id}") do
+        expect(page).to have_link("Delete Discount")
+        click_link "Delete Discount"
+        expect(current_path).to eq(merchant_bulk_discounts_path(@merchant1))
+      end
+
+      expect(page).to_not have_content("Percentage of Discount: 20%")
     end
   end
 end

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe BulkDiscount do
       click_button "Submit New Bulk Discount"
 
       expect(current_path).to eq(merchant_bulk_discounts_path(@merchant1))
-      save_and_open_page
       expect(page).to have_content("Percentage of Discount: 20%")
       expect(page).to have_content("Percentage of Discount: 50%")
     end


### PR DESCRIPTION
  - As a merchant
  - When I visit my bulk discounts index
  - Then next to each bulk discount I see a link to delete it
  - When I click this link
  - Then I am redirected back to the bulk discounts index page
  - And I no longer see the discount listed